### PR TITLE
Human-Only Command & Prisoner Antag

### DIFF
--- a/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Wildcards/prisoner.yml
+++ b/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Wildcards/prisoner.yml
@@ -5,7 +5,7 @@
   playTimeTracker: JobPrisoner
   startingGear: PrisonerGear
   alwaysUseSpawner: true
-  canBeAntag: false
+  canBeAntag: true # Spacious - enable prisoner antag
 #  whitelistRequired: true
   icon: "JobIconPrisoner"
   supervisors: job-supervisors-security
@@ -23,9 +23,11 @@
           traits:
             - ShadowkinBlackeye
   special:
-  - !type:AddComponentSpecial
-    components:
-      - type: Pacified
+  # - !type:AddComponentSpecial # Spacious - remove PacifiedComponent from prisoners
+  #   components:
+  #     - type: Pacified
+  - !type:AddImplantSpecial # Spacious - add tracking implant to prisoners
+    implants: [ TrackingImplant ]
 
 - type: startingGear
   id: PrisonerGear

--- a/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
+++ b/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
@@ -19,6 +19,9 @@
       min: 43200 #DeltaV 12 hours
     - !type:CharacterOverallTimeRequirement
       min: 144000 #40 hrs
+    - !type:CharacterSpeciesRequirement # Spacious - Human-only command
+      species:
+        - Human
   weight: 10
   startingGear: QuartermasterGear
   icon: "JobIconQuarterMaster"

--- a/Resources/Prototypes/Roles/Jobs/Command/captain.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/captain.yml
@@ -25,6 +25,9 @@
     - !type:CharacterOverallTimeRequirement # DeltaV - Playtime requirement
       min: 108000 # 30 hours
     - !type:CharacterWhitelistRequirement
+    - !type:CharacterSpeciesRequirement # Spacious - Human-only command
+      species:
+        - Human
   weight: 20
   startingGear: CaptainGear
   icon: "JobIconCaptain"

--- a/Resources/Prototypes/Roles/Jobs/Command/centcom_official.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/centcom_official.yml
@@ -3,6 +3,10 @@
   name: job-name-centcomoff
   description: job-description-centcomoff
   playTimeTracker: JobCentralCommandOfficial
+  requirements:
+    - !type:CharacterSpeciesRequirement # Spacious - Human-only command
+      species:
+        - Human
   setPreference: false
   startingGear: CentcomGear
   icon: "JobIconNanotrasen"

--- a/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
@@ -19,6 +19,9 @@
       min: 72000 # 20 hours
     - !type:CharacterOverallTimeRequirement # DeltaV - Playtime requirement
       min: 90000 # 25 hours
+    - !type:CharacterSpeciesRequirement # Spacious - Human-only command
+      species:
+        - Human
   weight: 10 # DeltaV - Changed HoP weight from 20 to 10 due to them not being more important than other Heads
   startingGear: HoPGear
   icon: "JobIconHeadOfPersonnel"

--- a/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
@@ -15,6 +15,9 @@
       min: 90000 # DeltaV - 25 hours
 #    - !type:OverallPlaytimeRequirement
 #      time: 72000 # DeltaV - 20 hours
+    - !type:CharacterSpeciesRequirement # Spacious - Human-only command
+      species:
+        - Human
   weight: 10
   startingGear: ChiefEngineerGear
   icon: "JobIconChiefEngineer"

--- a/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
@@ -27,6 +27,9 @@
         - !type:CharacterTraitRequirement
           traits:
             - ShadowkinBlackeye
+    - !type:CharacterSpeciesRequirement # Spacious - Human-only command
+      species:
+        - Human
   weight: 10
   startingGear: CMOGear
   icon: "JobIconChiefMedicalOfficer"

--- a/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
@@ -28,6 +28,9 @@
           inverted: true
           traits:
             - ShadowkinBlackeye
+    - !type:CharacterSpeciesRequirement # Spacious - Human-only command
+      species:
+        - Human
   weight: 10
   startingGear: ResearchDirectorGear
   icon: "JobIconResearchDirector"

--- a/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
@@ -16,6 +16,9 @@
     - !type:CharacterOverallTimeRequirement
       min: 90000 # DeltaV - 25 hours
     - !type:CharacterWhitelistRequirement
+    - !type:CharacterSpeciesRequirement # Spacious - Human-only command
+      species:
+        - Human
   weight: 10
   startingGear: HoSGear
   icon: "JobIconHeadOfSecurity"


### PR DESCRIPTION
# Description

Restricts the Command department to humans only.

Also removes the PacifiedComponent from prisoners, gives them the tracking implant by default, and make them eligible for being an antagonist.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added species restriction to key leadership roles, limiting them to human characters.
  - Allowed prisoners to take on antagonist roles and introduced a tracking implant mechanic.

- **Access Changes**
  - Modified Head of Security access list, adding "Corpsman" and removing "Brig" access.
  
- **Department Updates**
  - Updated department names (e.g., "Science" to "Epistemics").

These updates refine job eligibility criteria and enhance gameplay mechanics across various roles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->