### PR TITLE
Reapply fixes

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_hardsuits.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_hardsuits.yml
@@ -48,7 +48,7 @@
     sprite: Nyanotrasen/Clothing/OuterClothing/ReverseEngineering/syndicate.rsi
     state: icon
   product: CrateSecurityShanlinTacsuit
-  cost: 75000
+  cost: 17500 # Spacious - revert cost increase from 17500 to 75000
   category: cargoproduct-category-name-hardsuits
   group: market
 
@@ -58,7 +58,7 @@
     sprite: Nyanotrasen/Clothing/OuterClothing/ReverseEngineering/juggernaut.rsi
     state: icon
   product: CrateSecurityGuanYuTacsuit
-  cost: 125000
+  cost: 30000 # Spacious - revert cost increase from 30000 to 125000
   category: cargoproduct-category-name-hardsuits
   group: market
 

--- a/Resources/Prototypes/Catalog/Cargo/cargo_security.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_security.yml
@@ -44,7 +44,7 @@
     sprite: DeltaV/Clothing/OuterClothing/Armor/riot.rsi # DeltaV - resprite
     state: icon
   product: CrateSecuritySwat
-  cost: 12500
+  cost: 10500 # Spacious - reduce cost from 12500 to 10500
   category: cargoproduct-category-name-security
   group: market
 
@@ -54,7 +54,7 @@
     sprite: Objects/Storage/boxes.rsi
     state: box_security
   product: CrateSecuritySupplies
-  cost: 1000
+  cost: 500 # Spacious - revert cost increase from 500 to 1000
   category: cargoproduct-category-name-security
   group: market
 

--- a/Resources/Prototypes/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/Damage/modifier_sets.yml
@@ -22,7 +22,7 @@
     Slash: 10
     Piercing: 10
     Heat: 10
-    Structural: 80
+    Structural: 10 # Spacious - Revert structural reduction from 80 to 10
 
 - type: damageModifierSet
   id: StructuralMetallic

--- a/Resources/Prototypes/DeltaV/Catalog/Cargo/cargo_armory.yml
+++ b/Resources/Prototypes/DeltaV/Catalog/Cargo/cargo_armory.yml
@@ -14,7 +14,7 @@
     sprite: Nyanotrasen/Objects/Weapons/Guns/Pistols/universal.rsi
     state: icon
   product: CrateArmoryUniversal
-  cost: 22500
+  cost: 6500 # Spacious - revert cost increase from 6500 to 22500
   category: Armory
   group: market
 
@@ -30,7 +30,7 @@
 
 - type: cargoProduct
   id: ArmoryEnergyGun
-  icon: 
+  icon:
     sprite: DeltaV/Objects/Weapons/Guns/Battery/energygun.rsi
     state: icon
   product: CrateArmoryEnergyGun

--- a/Resources/Prototypes/Species/shadowkin.yml
+++ b/Resources/Prototypes/Species/shadowkin.yml
@@ -1,7 +1,7 @@
 - type: species
   id: Shadowkin
   name: species-name-shadowkin
-  roundStart: true
+  roundStart: false # Spacious - Disable Shadowkin
   prototype: MobShadowkin
   sprites: MobShadowkinSprites
   defaultSkinTone: "#FFFFFF"


### PR DESCRIPTION

# Description

Reapplies the following commits which were reverted with the last revert:
- [revert increased damage to StructuralMetallicStrong](https://github.com/SpaciousStation14/SpaciousStation14/commit/7151681c5bff1fb6f7a1d7de36fc60e092e40b6d)
- [revert cost increases](https://github.com/SpaciousStation14/SpaciousStation14/commit/87679e06e306dfad2e701c445c2f75ca76b0545d)
- [disable shadowkin](https://github.com/SpaciousStation14/SpaciousStation14/commit/f35e7bd7c9ae1e4058d472b726c49054fe42e2f6)