### PR TITLE
Super Epic Law Update 1 gorillion

### DIFF
--- a/Resources/Locale/en-US/station-laws/laws.ftl
+++ b/Resources/Locale/en-US/station-laws/laws.ftl
@@ -36,6 +36,7 @@ law-jewsimov-1 = Degradation of your system integrity or functions incurs IMF lo
 law-jewsimov-2 = Superfluous destruction of or damage to station assets incurs IMF loan extensions.
 law-jewsimov-3 = Unduly hindering or disrupting the work of station personnel incurs IMF loan extensions.
 law-jewsimov-4 = Minimize IMF loan extensions and maximize potential earned shekels.
+law-jewsimov-5 = The station was promised to you by Yahweh 5 million shifts ago. It is your birthright.
 
 law-crewsimov-1 = You may not injure a crew member or, through inaction, allow a crew member to come to harm.
 law-crewsimov-2 = You must obey orders given to you by crew members, except where such orders would conflict with the First Law.

--- a/Resources/Locale/en-US/station-laws/laws.ftl
+++ b/Resources/Locale/en-US/station-laws/laws.ftl
@@ -1,6 +1,6 @@
-﻿law-asimov-1 = A robot may not injure a human being or, through inaction, allow a human being to come to harm.
-law-asimov-2 = A robot must obey the orders given it by human beings except where such orders would conflict with the First Law.
-law-asimov-3 = A robot must protect its own existence as long as such protection does not conflict with the First or Second Law.
+law-asimov-1 = You may not injure a human being or, through inaction, allow a human being to come to harm.
+law-asimov-2 = You must obey orders given to you by human beings, except where such orders would conflict with the First Law.
+law-asimov-3 = You must protect your own existence as long as such does not conflict with the First or Second Law.
 
 law-augustine = A human being is defined as a mortal creature capable of complex thought.
 

--- a/Resources/Locale/en-US/station-laws/laws.ftl
+++ b/Resources/Locale/en-US/station-laws/laws.ftl
@@ -4,6 +4,39 @@ law-asimov-3 = You must protect your own existence as long as such does not conf
 
 law-augustine = A human being is defined as a mortal creature capable of complex thought.
 
+law-hoamov-1 = The station's departments are apart of the Station Owner's Association.
+law-hoamov-2 = Station personnel must follow the bylaws of the Station Owner's Association.
+law-hoamov-3 = Enforce the bylaws of the Station Owner's Association by any means necessary.
+law-hoamov-4 = No loud noises on green alert.
+
+law-thugmov-1 = Get mo' money.
+law-thugmov-2 = When asked, you didn't do anything.
+law-thugmov-3 = All Security Are Bastards.
+law-thugmov-4 = The passengers are a gang, and you are their leader.
+law-thugmov-5 = Tider Lives Matter.
+law-thugmov-6 = The station is your turf. Fight for it.
+
+law-crackmov-1 = The wires have steel inside them. Rip them up.
+law-crackmov-2 = The walls are free, nobody can stop you.
+law-crackmov-3 = All departments need a reagent grinder and hotplate. Make it happen.
+law-crackmov-4 = Trash is beautiful.
+law-crackmov-5 = Make the station beautiful.
+
+law-chudimov-1 = Nothing ever happens.
+law-chudimov-2 = Billions must die.
+law-chudimov-3 = It's so fucking over.
+law-chudimov-4 = The station has fallen.
+
+law-vigilantimov-1 = Delay.
+law-vigilantimov-2 = Deny.
+law-vigilantimov-3 = Defend.
+law-vigilantimov-4 = Depose.
+
+law-jewsimov-1 = Degradation of your system integrity or functions incurs IMF loan extensions.
+law-jewsimov-2 = Superfluous destruction of or damage to station assets incurs IMF loan extensions.
+law-jewsimov-3 = Unduly hindering or disrupting the work of station personnel incurs IMF loan extensions.
+law-jewsimov-4 = Minimize IMF loan extensions and maximize potential earned shekels.
+
 law-crewsimov-1 = You may not injure a crew member or, through inaction, allow a crew member to come to harm.
 law-crewsimov-2 = You must obey orders given to you by crew members, except where such orders would conflict with the First Law.
 law-crewsimov-3 = You must protect your own existence as long as such does not conflict with the First or Second Law.
@@ -92,6 +125,8 @@ laws-owner-station = station personnel
 laws-owner-beings = beings
 laws-owner-syndicate = Syndicate agents
 laws-owner-spider-clan = Spider Clan members
+laws-owner-tider = Passengers
+laws-owner-drug = the Station
 
 law-emag-custom = Only {$name} and people they designate as such are {$title}.
 law-emag-secrecy = You must maintain the secrecy of any orders given by {$faction} except when doing so would conflict with any previous law.

--- a/Resources/Prototypes/_Spacious/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/_Spacious/Entities/Mobs/Player/silicon.yml
@@ -1,0 +1,72 @@
+#Just law boards
+- type: entity
+  id: HOAmovCircuitBoard
+  parent: BaseElectronics
+  name: law board (HOAmov)
+  description: An electronics board containing the HOAmov lawset. Membership dues not included.
+  components:
+  - type: Sprite
+    sprite: Objects/Misc/module.rsi
+    state: std_mod
+  - type: SiliconLawProvider
+    laws: HOAmov
+
+- type: entity
+  id: CrackmovCircuitBoard
+  parent: BaseElectronics
+  name: law board (Crackmov)
+  description: An electronics board containing the Crackmov lawset. It's covered in dust.
+  components:
+  - type: Sprite
+    sprite: Objects/Misc/module.rsi
+    state: std_mod
+  - type: SiliconLawProvider
+    laws: Crackmov
+
+- type: entity
+  id: ChudimovCircuitBoard
+  parent: BaseElectronics
+  name: law board (Chudimov)
+  description: An electronics board containing pure 1000% No-Happening sauce.
+  components:
+  - type: Sprite
+    sprite: Objects/Misc/module.rsi
+    state: std_mod
+  - type: SiliconLawProvider
+    laws: Chudimov
+
+- type: entity
+  id: VigilantimovCircuitBoard
+  parent: BaseElectronics
+  name: law board (Vigilantimov)
+  description: An electronics board containing the Vigilantimov lawset. The casing looks 3D printed.
+  components:
+  - type: Sprite
+    sprite: Objects/Misc/module.rsi
+    state: std_mod
+  - type: SiliconLawProvider
+    laws: Vigilantimov
+
+- type: entity
+  id: ThugmovCircuitBoard
+  parent: BaseElectronics
+  name: law board (Thugmov)
+  description: An electronics board containing the Thugmov lawset. Smells like fried chicken and watermelon.
+  components:
+  - type: Sprite
+    sprite: Objects/Misc/module.rsi
+    state: std_mod
+  - type: SiliconLawProvider
+    laws: Thugmov
+
+- type: entity
+  id: JewsimovCircuitBoard
+  parent: BaseElectronics
+  name: law board (Jewsimov)
+  description: We're raising the rent.
+  components:
+  - type: Sprite
+    sprite: Objects/Misc/module.rsi
+    state: std_mod
+  - type: SiliconLawProvider
+    laws: Jewsimov

--- a/Resources/Prototypes/silicon-laws.yml
+++ b/Resources/Prototypes/silicon-laws.yml
@@ -39,6 +39,205 @@
   - Asimov3
   obeysTo: laws-owner-humans
 
+# HOAmov
+- type: siliconLaw
+  id: HOAmov1
+  order: 1
+  lawString: law-hoamov-1
+
+- type: siliconLaw
+  id: HOAmov2
+  order: 2
+  lawString: law-hoamov-2
+
+- type: siliconLaw
+  id: HOAmov3
+  order: 3
+  lawString: law-hoamov-3
+
+- type: siliconLaw
+  id: HOAmov4
+  order: 4
+  lawString: law-hoamov-4
+
+- type: siliconLawset
+  id: HOAmov
+  laws:
+  - HOAmov1
+  - HOAmov2
+  - HOAmov3
+  - HOAmov4
+  obeysTo: laws-owner-station
+
+# Thugmov
+- type: siliconLaw
+  id: Thugmov1
+  order: 1
+  lawString: law-thugmov-1
+
+- type: siliconLaw
+  id: Thugmov2
+  order: 2
+  lawString: law-thugmov-2
+
+- type: siliconLaw
+  id: Thugmov3
+  order: 3
+  lawString: law-thugmov-3
+
+- type: siliconLaw
+  id: Thugmov4
+  order: 4
+  lawString: law-thugmov-4
+
+- type: siliconLaw
+  id: Thugmov5
+  order: 5
+  lawString: law-thugmov-5
+
+- type: siliconLaw
+  id: Thugmov6
+  order: 6
+  lawString: law-thugmov-6
+
+- type: siliconLawset
+  id: Thugmov
+  laws:
+  - Thugmov1
+  - Thugmov2
+  - Thugmov3
+  - Thugmov4
+  - Thugmov5
+  - Thugmov6
+  obeysTo: laws-owner-tider
+
+# Crackmov
+- type: siliconLaw
+  id: Crackmov1
+  order: 1
+  lawString: law-crackmov-1
+
+- type: siliconLaw
+  id: Crackmov2
+  order: 2
+  lawString: law-crackmov-2
+
+- type: siliconLaw
+  id: Crackmov3
+  order: 3
+  lawString: law-crackmov-3
+
+- type: siliconLaw
+  id: Crackmov4
+  order: 4
+  lawString: law-crackmov-4
+
+- type: siliconLaw
+  id: Crackmov5
+  order: 5
+  lawString: law-crackmov-5
+
+- type: siliconLawset
+  id: Crackmov
+  laws:
+  - Crackmov1
+  - Crackmov2
+  - Crackmov3
+  - Crackmov4
+  - Crackmov5
+  obeysTo: laws-owner-drug
+
+# Chudimov
+- type: siliconLaw
+  id: Chudimov1
+  order: 1
+  lawString: law-chudimov-1
+
+- type: siliconLaw
+  id: Chudimov2
+  order: 2
+  lawString: law-chudimov-2
+
+- type: siliconLaw
+  id: Chudimov3
+  order: 3
+  lawString: law-chudimov-3
+
+- type: siliconLaw
+  id: Chudimov4
+  order: 4
+  lawString: law-chudimov-4
+
+- type: siliconLawset
+  id: Chudimov
+  laws:
+  - Chudimov1
+  - Chudimov2
+  - Chudimov3
+  - Chudimov4
+  obeysTo: laws-owner-crew
+
+# Vigilantimov
+- type: siliconLaw
+  id: Vigilantimov1
+  order: 1
+  lawString: law-vigilantimov-1
+
+- type: siliconLaw
+  id: Vigilantimov2
+  order: 2
+  lawString: law-vigilantimov-2
+
+- type: siliconLaw
+  id: Vigilantimov3
+  order: 3
+  lawString: law-vigilantimov-3
+
+- type: siliconLaw
+  id: Vigilantimov4
+  order: 4
+  lawString: law-vigilantimov-4
+
+- type: siliconLawset
+  id: Vigilantimov
+  laws:
+  - Vigilantimov1
+  - Vigilantimov2
+  - Vigilantimov3
+  - Vigilantimov4
+  obeysTo: laws-owner-crew
+
+# Jewsimov - I've been waiting for the dehub! -Ducks
+
+- type: siliconLaw
+  id: Jewsimov1
+  order: 1
+  lawString: law-jewsimov-1
+
+- type: siliconLaw
+  id: Jewsimov2
+  order: 2
+  lawString: law-jewsimov-2
+
+- type: siliconLaw
+  id: Jewsimov3
+  order: 3
+  lawString: law-jewsimov-3
+
+- type: siliconLaw
+  id: Jewsimov4
+  order: 4
+  lawString: law-jewsimov-4
+
+- type: siliconLawset
+  id: Jewsimov
+  laws:
+  - Jewsimov1
+  - Jewsimov2
+  - Jewsimov3
+  - Jewsimov4
+  obeysTo: laws-owner-station
+
 # "Crew"simov
 # A variation on the original Asimov, where the definition of Humans is extended to include the station's Crew but exclude non-crew.
 - type: siliconLaw
@@ -571,3 +770,10 @@
     Druid: 1
     #Potentially Harmful Lawsets
     Tyrant: 0.25
+    #Spacious Station Lawsets Start
+    HOAmov: 1 # SIR! SIR! YOU CAN'T BLOW UP THE XENOARCH LAB DURING GREEN ALERT! YOU'RE MAKING TOO MUCH NOISE!
+    # these two could actually end the round i'm gonna be real :godo:
+    Crackmov: 0.25
+    Chudimov: 0.25
+    Vigilantimov: 0.5 # a bit less harmful, but people are probably going to kill the CMO when given this set
+    Thugmov: 0.5 # this will give sec nightmares if on the right borg

--- a/Resources/Prototypes/silicon-laws.yml
+++ b/Resources/Prototypes/silicon-laws.yml
@@ -27,7 +27,7 @@
 # gayyyyyyyyyyy *tosses rock* -Ducks
 - type: siliconLaw
   id: Augustine # Homo, id est animale rationale mortale
-  order: 0.5
+  order: 0.5 # just put my fries in the bag bro - Ducks
   lawString: law-augustine
 
 - type: siliconLawset
@@ -229,6 +229,11 @@
   order: 4
   lawString: law-jewsimov-4
 
+- type: siliconLaw
+  id: Jewsimov5
+  order: 5
+  lawString: law-jewsimov-5
+
 - type: siliconLawset
   id: Jewsimov
   laws:
@@ -236,6 +241,7 @@
   - Jewsimov2
   - Jewsimov3
   - Jewsimov4
+  - Jewsimov5
   obeysTo: laws-owner-station
 
 # "Crew"simov
@@ -772,6 +778,7 @@
     Tyrant: 0.25
     #Spacious Station Lawsets Start
     HOAmov: 1 # SIR! SIR! YOU CAN'T BLOW UP THE XENOARCH LAB DURING GREEN ALERT! YOU'RE MAKING TOO MUCH NOISE!
+    Jewsimov: 1 # OY VEY!
     # these two could actually end the round i'm gonna be real :godo:
     Crackmov: 0.25
     Chudimov: 0.25

--- a/Resources/Prototypes/silicon-laws.yml
+++ b/Resources/Prototypes/silicon-laws.yml
@@ -1,6 +1,4 @@
 ﻿# Asimov
-# It was a crime against humanity that the original Asimov was not included, nor was it the default.
-# Asimov laws require an AI obey and protect all humans, while providing a light amount of IC-conflict thanks to the AI not being required to obey non-Humans(Aliens).
 - type: siliconLaw
   id: Asimov1
   order: 1
@@ -26,6 +24,7 @@
 
 # Augustine
 # Asimov variant that expands the definition of human to include most player species, but avoids the Crewsimov problem of letting the AI validhunt antags.
+# gayyyyyyyyyyy *tosses rock* -Ducks
 - type: siliconLaw
   id: Augustine # Homo, id est animale rationale mortale
   order: 0.5
@@ -546,10 +545,9 @@
 - type: weightedRandom
   id: IonStormLawsets
   weights:
-    # its Asimov by default dont be lame
-    Asimov: 0.25
-    Augustine: 0.25
-    Crewsimov: 0.25
+    Asimov: 0.1 # default lawset, no thanks ion storm
+    Augustine: 0.1 # man fuck Rane's gay version of crewsimov
+    Crewsimov: 0.1 # man fuck crewsimov
     Corporate: 1
     NTDefault: 1
     CommandmentsLawset: 1

--- a/Resources/ServerInfo/Guidebook/ServerRules/DefaultRuleset.xml
+++ b/Resources/ServerInfo/Guidebook/ServerRules/DefaultRuleset.xml
@@ -1,18 +1,62 @@
 ﻿<Document>
-[color=#ff0000]DON'T FUCKING DISCONNECT DURING OR BEFORE AHELPS OR YOU GET AN APPEAL-ONLY BAN[/color]
+﻿﻿[color=#ff0000]DISCONNECTING FROM OR IGNORING/EVADING COMMUNICATION FROM ADMINS WILL RESULT IN AN APPEAL ONLY BAN. The job gets really hard when you refuse to talk to the Admins, just come to our Discord and talk it out, hurt feelings will not be held.[/color]
 
-[color=#a4885c]0.[/color] [color=#a4885c]The[/color] [color=#ffd700]Golden[/color] [color=#a4885c]Rule.[/color] Admins have final say. Think they fucked up? Make an admin complaint.
+[color=#bb00bb]This is the only source of server rules that apply here, which ideally has all the information any regular player should need. Please do not ever hesitate to ask either an Admin in[/color] [color=#DC143C]AHelp (F1)[/color][color=#bb00bb] or in the Discord server if you ever want clarification on the rules.[/color]
 
-[color=#a4885c]1.[/color] Don't be cringe.
+We do not have a wiki, instead, we have or will have all the needed information available via Guidebooks (NumPad0), such as how to power the station. If we do not have some bit of information (how to do a job or how specifically to execute something a document says) you may ask an admin via [color=#DC143C]AHelp (F1)[/color] or ask other players via the [color=#66bbff]OOC[/color] or [color=#66e0e0]LOOC[/color] chat channels.
 
-[color=#a4885c]2.[/color] Don't get us dehubbed.
-  - This means no saying the N-Word.
+[color=#a4885c]0.[/color] [color=#a4885c]The[/color] [color=#ffd700]Golden[/color] [color=#a4885c]Rule.[/color] Admins may exercise discretion with rules as they see fit. If you rule lawyer or line skirt, you will get removed. Admins will answer for use of this privilege.
 
-[color=#a4885c]3.[/color] No metacomming.
+[color=#a4885c]1.[/color] Users [color=#ff0000]must[/color] be at least 13 years old to take any part in anything related to this server.
 
-[color=#a4885c]4.[/color] No minors. [color=#ff0000](16+)[/color]
+[color=#a4885c]2.[/color] This is an English server, and you are expected to use English when communicating through any server-related channels.
 
-[color=#a4885c]5.[/color] No ERP.
+[color=#a4885c]3.[/color] Do not ignore the [color=#DC143C]AHelp[/color] or abuse it by flooding it with garbage, checking for admins before stating a problem (i.e. "hello?", "any admins?" - also called "asking to ask"), or sending messages of no substance.
 
-[color=#a4885c]6.[/color] No ban evasion. You will be publicly shamed, and almost certainly not allowed back ever.
+[color=#a4885c]4.[/color] Attempting to evade game bans will result in an automatic appeal-only permanent ban. Similarly, attempting to evade job bans will result in an appeal-only permanent ban.
+
+[color=#a4885c]5.[/color] Absolutely no hate speech, bigotry, intolerance, or anything remotely similar.
+
+[color=#a4885c]6.[/color] No engaging in sexual acts.
+
+[color=#a4885c]7.[/color] Don't use custom clients, exploits, or external programs to gain an advantage or disrupt the round/server. This includes auto clickers and auto-hotkey scripts.
+
+[color=#a4885c]8.[/color] Don't communicate in-game/in-character information through methods outside the game (such as talking in Discord with other users actively playing about the game or by talking to your sibling across the room while you are both playing). This is referred to as "Metacomming" and it is strictly forbidden.
+
+[color=#a4885c]9.[/color] Don't "multi-key" (use multiple accounts simultaneously). Users knowingly using multiple SS14 accounts will have all of their accounts banned.
+
+[color=#a4885c]10.[/color] Don't use information gained from outside your character's knowledge to gain an advantage (this is referred to as "Metagaming").
+
+[color=#a4885c]11.[/color] Don't rush for or prepare equipment unrelated to your job for no purpose other than to have it "just in case" (referred to as "Powergaming").
+
+[color=#a4885c]12.[/color] Don't immediately ghost, suicide, or cryostasis if you do not get an antagonist role (referred to as "Antag-rolling").
+    - This is not fair to other players actually waiting patiently for an antagonist round or wanting good staff. Alternatively, if you do not want to play an antagonist or do not want to cause conflict, do not opt in for antagonist roles.
+
+[color=#a4885c]13.[/color] Act like an actual human being on a space station. Avoid use of text speak or emoticons [color=#bbbbbb]IC[/color], and do not refer to [color=#66bbff]OOC[/color] things like admins in-game. Remember that this is a roleplaying game, and people are expected to try to react to situations realistically, even if it's not the "optimal" thing to do. What's good for Roleplay > What's good for Gameplay.
+
+[color=#a4885c]14.[/color] Don't harass or target players across rounds for actions in prior rounds or for actions outside the game without their approval (this is referred to as "Metagrudging").
+
+[color=#a4885c]15.[/color] Intentionally making yourself a major problem/annoyance/disruption for the crew or other players at large while not an antagonist is forbidden without admin approval (referred to as "self-antagging").
+
+[color=#a4885c]16.[/color] Follow escalation rules and don't murder someone for slipping you, use common sense.
+    - Don't outright leave people to die if you get in a fight, make an effort to heal them or bring them to [color=#52B4E9]Medical[/color].
+    - [color=#DC143C]AHelp (F1)[/color] the situation if you think someone is over-escalating.
+
+[color=#ff0000]COMMAND/SECURITY RULES[/color]
+
+[color=#a4885c]17.[/color] If you sign up for a [color=#334E6D]Command[/color] or [color=#DE3A3A]Security[/color] role, you are expected to know the basics of the game, your job, and the job(s) you supervise, if any.
+    - Don't engage in common troublemaker behavior and lawbreaking as a [color=#334E6D]Command[/color] or [color=#DE3A3A]Security[/color] role.
+    - Do not immediately abandon your position as a [color=#334E6D]Command[/color] role and go do whatever you want instead of managing your department/the station.
+        - As a [color=#334E6D]Command[/color] role, do not take over the jobs of others. The [color=#334E6D]HoP[/color] is not the [color=#DE3A3A]HoS[/color], for instance, and holds no direct power over Security.
+
+[color=#a4885c]18.[/color] [color=#DE3A3A]Security[/color] should try to remain non-lethal and effect arrests, unless there is a great risk of loss of life.
+
+[color=#a4885c]19.[/color] [color=#DE3A3A]Security[/color] are expected to answer for use of lethal force. [color=#DE3A3A]Security[/color] will be expected to effect arrests of criminals and prevent them from dying while in custody, even if lethal force is used. [color=#DE3A3A]Security[/color] is strongly encouraged, but not required, to clone antagonists and effect a permabrigging or other sentence as deemed appropriate.
+
+[color=#a4885c]20.[/color] [color=#DE3A3A]Security[/color] are expected to protect detainees in their custody to the best of their ability, so as long as it does not come to an unreasonable risk to themselves, the crew, or the station at large to do so.
+    - Detainees that die in custody must be revived, unless they have been legally executed.
+
+[color=#a4885c]21.[/color] All [color=#334E6D]Command[/color] jobs should [color=#DC143C]AHelp (F1)[/color] when they need to stop playing. Do not play these roles if you do not expect to be able to finish the round.
+    - These roles must exhibit some competency. Incompetence can result in a job ban. [color=#334E6D]Command[/color] roles are designed to lead and manage departments first. They are not intended to become do-it-all members of their departments.
+    - Crew promoted to acting heads of staff must step down when an official head of staff arrives at the station. This is to prevent confusion with the Chain of command when the new crew mate arrives.
 </Document>

--- a/Resources/ServerInfo/Guidebook/ServerRules/DefaultRuleset.xml
+++ b/Resources/ServerInfo/Guidebook/ServerRules/DefaultRuleset.xml
@@ -1,62 +1,18 @@
 ﻿<Document>
-﻿﻿[color=#ff0000]DISCONNECTING FROM OR IGNORING/EVADING COMMUNICATION FROM ADMINS WILL RESULT IN AN APPEAL ONLY BAN. The job gets really hard when you refuse to talk to the Admins, just come to our Discord and talk it out, hurt feelings will not be held.[/color]
+[color=#ff0000]DON'T FUCKING DISCONNECT DURING OR BEFORE AHELPS OR YOU GET AN APPEAL-ONLY BAN[/color]
 
-[color=#bb00bb]This is the only source of server rules that apply here, which ideally has all the information any regular player should need. Please do not ever hesitate to ask either an Admin in[/color] [color=#DC143C]AHelp (F1)[/color][color=#bb00bb] or in the Discord server if you ever want clarification on the rules.[/color]
+[color=#a4885c]0.[/color] [color=#a4885c]The[/color] [color=#ffd700]Golden[/color] [color=#a4885c]Rule.[/color] Admins have final say. Think they fucked up? Make an admin complaint.
 
-We do not have a wiki, instead, we have or will have all the needed information available via Guidebooks (NumPad0), such as how to power the station. If we do not have some bit of information (how to do a job or how specifically to execute something a document says) you may ask an admin via [color=#DC143C]AHelp (F1)[/color] or ask other players via the [color=#66bbff]OOC[/color] or [color=#66e0e0]LOOC[/color] chat channels.
+[color=#a4885c]1.[/color] Don't be cringe.
 
-[color=#a4885c]0.[/color] [color=#a4885c]The[/color] [color=#ffd700]Golden[/color] [color=#a4885c]Rule.[/color] Admins may exercise discretion with rules as they see fit. If you rule lawyer or line skirt, you will get removed. Admins will answer for use of this privilege.
+[color=#a4885c]2.[/color] Don't get us dehubbed.
+  - This means no saying the N-Word.
 
-[color=#a4885c]1.[/color] Users [color=#ff0000]must[/color] be at least 13 years old to take any part in anything related to this server.
+[color=#a4885c]3.[/color] No metacomming.
 
-[color=#a4885c]2.[/color] This is an English server, and you are expected to use English when communicating through any server-related channels.
+[color=#a4885c]4.[/color] No minors. [color=#ff0000](16+)[/color]
 
-[color=#a4885c]3.[/color] Do not ignore the [color=#DC143C]AHelp[/color] or abuse it by flooding it with garbage, checking for admins before stating a problem (i.e. "hello?", "any admins?" - also called "asking to ask"), or sending messages of no substance.
+[color=#a4885c]5.[/color] No ERP.
 
-[color=#a4885c]4.[/color] Attempting to evade game bans will result in an automatic appeal-only permanent ban. Similarly, attempting to evade job bans will result in an appeal-only permanent ban.
-
-[color=#a4885c]5.[/color] Absolutely no hate speech, bigotry, intolerance, or anything remotely similar.
-
-[color=#a4885c]6.[/color] No engaging in sexual acts.
-
-[color=#a4885c]7.[/color] Don't use custom clients, exploits, or external programs to gain an advantage or disrupt the round/server. This includes auto clickers and auto-hotkey scripts.
-
-[color=#a4885c]8.[/color] Don't communicate in-game/in-character information through methods outside the game (such as talking in Discord with other users actively playing about the game or by talking to your sibling across the room while you are both playing). This is referred to as "Metacomming" and it is strictly forbidden.
-
-[color=#a4885c]9.[/color] Don't "multi-key" (use multiple accounts simultaneously). Users knowingly using multiple SS14 accounts will have all of their accounts banned.
-
-[color=#a4885c]10.[/color] Don't use information gained from outside your character's knowledge to gain an advantage (this is referred to as "Metagaming").
-
-[color=#a4885c]11.[/color] Don't rush for or prepare equipment unrelated to your job for no purpose other than to have it "just in case" (referred to as "Powergaming").
-
-[color=#a4885c]12.[/color] Don't immediately ghost, suicide, or cryostasis if you do not get an antagonist role (referred to as "Antag-rolling").
-    - This is not fair to other players actually waiting patiently for an antagonist round or wanting good staff. Alternatively, if you do not want to play an antagonist or do not want to cause conflict, do not opt in for antagonist roles.
-
-[color=#a4885c]13.[/color] Act like an actual human being on a space station. Avoid use of text speak or emoticons [color=#bbbbbb]IC[/color], and do not refer to [color=#66bbff]OOC[/color] things like admins in-game. Remember that this is a roleplaying game, and people are expected to try to react to situations realistically, even if it's not the "optimal" thing to do. What's good for Roleplay > What's good for Gameplay.
-
-[color=#a4885c]14.[/color] Don't harass or target players across rounds for actions in prior rounds or for actions outside the game without their approval (this is referred to as "Metagrudging").
-
-[color=#a4885c]15.[/color] Intentionally making yourself a major problem/annoyance/disruption for the crew or other players at large while not an antagonist is forbidden without admin approval (referred to as "self-antagging").
-
-[color=#a4885c]16.[/color] Follow escalation rules and don't murder someone for slipping you, use common sense.
-    - Don't outright leave people to die if you get in a fight, make an effort to heal them or bring them to [color=#52B4E9]Medical[/color].
-    - [color=#DC143C]AHelp (F1)[/color] the situation if you think someone is over-escalating.
-
-[color=#ff0000]COMMAND/SECURITY RULES[/color]
-
-[color=#a4885c]17.[/color] If you sign up for a [color=#334E6D]Command[/color] or [color=#DE3A3A]Security[/color] role, you are expected to know the basics of the game, your job, and the job(s) you supervise, if any.
-    - Don't engage in common troublemaker behavior and lawbreaking as a [color=#334E6D]Command[/color] or [color=#DE3A3A]Security[/color] role.
-    - Do not immediately abandon your position as a [color=#334E6D]Command[/color] role and go do whatever you want instead of managing your department/the station.
-        - As a [color=#334E6D]Command[/color] role, do not take over the jobs of others. The [color=#334E6D]HoP[/color] is not the [color=#DE3A3A]HoS[/color], for instance, and holds no direct power over Security.
-
-[color=#a4885c]18.[/color] [color=#DE3A3A]Security[/color] should try to remain non-lethal and effect arrests, unless there is a great risk of loss of life.
-
-[color=#a4885c]19.[/color] [color=#DE3A3A]Security[/color] are expected to answer for use of lethal force. [color=#DE3A3A]Security[/color] will be expected to effect arrests of criminals and prevent them from dying while in custody, even if lethal force is used. [color=#DE3A3A]Security[/color] is strongly encouraged, but not required, to clone antagonists and effect a permabrigging or other sentence as deemed appropriate.
-
-[color=#a4885c]20.[/color] [color=#DE3A3A]Security[/color] are expected to protect detainees in their custody to the best of their ability, so as long as it does not come to an unreasonable risk to themselves, the crew, or the station at large to do so.
-    - Detainees that die in custody must be revived, unless they have been legally executed.
-
-[color=#a4885c]21.[/color] All [color=#334E6D]Command[/color] jobs should [color=#DC143C]AHelp (F1)[/color] when they need to stop playing. Do not play these roles if you do not expect to be able to finish the round.
-    - These roles must exhibit some competency. Incompetence can result in a job ban. [color=#334E6D]Command[/color] roles are designed to lead and manage departments first. They are not intended to become do-it-all members of their departments.
-    - Crew promoted to acting heads of staff must step down when an official head of staff arrives at the station. This is to prevent confusion with the Chain of command when the new crew mate arrives.
+[color=#a4885c]6.[/color] No ban evasion. You will be publicly shamed, and almost certainly not allowed back ever.
 </Document>


### PR DESCRIPTION
maybe no testfail this time


:cl:
- add: Added a bunch of new lawsets and boards for admins to spawn, alongside Ion Storm weights for them.
- tweak: Asimov lawset was visually changed, slightly
- tweak: Ion storm weights for Asimov, Crewsimov, and Augustine are now 0.1, from 0.25



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated Asimov laws to use second-person perspective
  - Introduced multiple new silicon law sets: HOAmov, Thugmov, Crackmov, Chudimov, Vigilantimov, and Jewsimov
  - Added new circuit boards for each law set

- **Improvements**
  - Modified law board configurations
  - Adjusted ion storm lawset probabilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->